### PR TITLE
APImanager mdb load

### DIFF
--- a/APIManager/Patcher.cs
+++ b/APIManager/Patcher.cs
@@ -74,7 +74,9 @@ public static class Patcher
 				}
 			}
 
-			__result = Assembly.Load(File.ReadAllBytes(__0));
+			string mdb = __0 + ".mdb";
+			__result = File.Exists(mdb) ? Assembly.Load(File.ReadAllBytes(__0), File.ReadAllBytes(mdb)) : Assembly.Load(File.ReadAllBytes(__0));
+			
 			return false;
 		}
 		return true;


### PR DESCRIPTION
APImanager makes dll load without mdb files so its impossible to debug your own dll if there is any APImanager mod user in chainloader. We fix it